### PR TITLE
Improved document modifier for multilingual field with defined suffix name

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/VitroSearchTermNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/VitroSearchTermNames.java
@@ -70,5 +70,11 @@ public class VitroSearchTermNames {
 
 	/** Source institution name */
 	public static final String SITE_NAME = "siteName";
+	
+	/** Multilingual sort field suffix */
+	public static final String SORT_SUFFIX = "_label_sort";
+	
+	/** Multilingual label field suffix */
+	public static final String LABEL_DISPLAY_SUFFIX = "_label_display";
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrFieldInitializer.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrFieldInitializer.java
@@ -1,0 +1,72 @@
+package edu.cornell.mannlib.vitro.webapp.searchengine.solr;
+
+import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
+import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.SORT_SUFFIX;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.util.SimpleOrderedMap;
+
+public class SolrFieldInitializer {
+
+	static void initializeFields(SolrClient queryEngine, ConcurrentUpdateSolrClient updateEngine) throws Exception {
+		Set<String> fieldSuffixes = new HashSet<>(Arrays.asList(SORT_SUFFIX, LABEL_DISPLAY_SUFFIX));
+		excludeMatchedFields(fieldSuffixes, queryEngine, "dynamicFields");
+		excludeMatchedFields(fieldSuffixes, queryEngine, "fields");
+		createMissingFields(fieldSuffixes, updateEngine);
+	}
+
+	private static void createMissingFields(Set<String> fieldSuffixes, ConcurrentUpdateSolrClient updateEngine)
+			throws Exception {
+		for (String suffix : fieldSuffixes) {
+			Map<String, Object> fieldAttributes = getFieldAttributes(suffix);
+			SchemaRequest.AddDynamicField request = new SchemaRequest.AddDynamicField(fieldAttributes);
+			SchemaResponse.UpdateResponse response = request.process(updateEngine);
+			if (response.getStatus() != 0) {
+				throw new Exception("Creation of missing solr field '*" + suffix + "' failed");
+			}
+		}
+	}
+
+	private static Map<String, Object> getFieldAttributes(String suffix) {
+		Map<String, Object> fieldAttributes = new HashMap<String, Object>();
+		fieldAttributes.put("type", "string");
+		fieldAttributes.put("stored", "true");
+		fieldAttributes.put("indexed", "true");
+		fieldAttributes.put("name", "*" + suffix);
+		return fieldAttributes;
+	}
+
+	private static void excludeMatchedFields(Set<String> fieldSuffixes, SolrClient queryEngine, String fieldType)
+			throws Exception {
+		SolrQuery query = new SolrQuery();
+		query.add(CommonParams.QT, "/schema/" + fieldType.toLowerCase());
+		QueryResponse response = queryEngine.query(query);
+		ArrayList<SimpleOrderedMap> fieldList = (ArrayList<SimpleOrderedMap>) response.getResponse().get(fieldType);
+		if (fieldList == null) {
+			return;
+		}
+		Set<String> it = new HashSet<>(fieldSuffixes);
+		for (String target : it) {
+			for (SimpleOrderedMap field : fieldList) {
+				String fieldName = (String) field.get("name");
+				if (fieldName.endsWith(target)) {
+					fieldSuffixes.remove(target);
+				}
+			}
+		}
+	}
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
@@ -76,7 +76,9 @@ public class SolrSearchEngine implements SearchEngine {
 			// no apparent 7.4.0 analogy to `setPollQueueTime(25)`
 
 			updateEngine = updateBuilder.build();
-
+			
+			SolrFieldInitializer.initializeFields(queryEngine, updateEngine);
+			
 			css.info("Set up the Solr search engine; URL = '" + solrServerUrlString + "'.");
 		} catch (Exception e) {
 			css.fatal("Could not set up the Solr search engine", e);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
@@ -141,7 +141,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return false;
 	}
 
-	protected List<String> getTextForQueries(Individual ind) {
+	private List<String> getTextForQueries(Individual ind) {
 		List<String> list = new ArrayList<>();
 		for (String query : queries) {
 			list.addAll(getTextForQuery(query, ind));
@@ -149,7 +149,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return list;
 	}
 
-	protected List<String> getTextForQuery(String query, Individual ind) {
+	private List<String> getTextForQuery(String query, Individual ind) {
 		try {
 			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
 					ind.getURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
@@ -5,11 +5,9 @@ package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
 import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.createSelectQueryContext;
 import static edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup.PROPERTY_SELECTABLE_LOCALES;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -20,7 +18,6 @@ import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.filter.LanguageFilteringRDFService;
-import edu.cornell.mannlib.vitro.webapp.utils.LocaleUtility;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationReader;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ContextModelsUser;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
@@ -37,9 +34,6 @@ import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
  * 
  * All of the other result fields in each row of each query will be converted to
  * strings and added to the field.
- * 
- * By default only the first value is added to the field. To save all values
- * specify :multiValued "true" in document modifier configuration. 
  *
  */
 public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDocumentModifier
@@ -50,16 +44,9 @@ public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDo
 
 	private ArrayList<String> locales = new ArrayList<>();
 
-	private boolean multiValued = false;
-
 	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasTargetSuffix")
 	public void setTargetSuffix(String fieldSuffix) {
 		this.fieldSuffix = fieldSuffix;
-	}
-
-	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#multiValued")
-	public void setMultiValued(String multiValued) {
-		this.multiValued = Boolean.parseBoolean(multiValued);
 	}
 
 	@Override
@@ -70,17 +57,10 @@ public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDo
 				for (String locale : map.keySet()) {
 					List<String> values = map.get(locale);
 					String fieldName = locale + fieldSuffix; 
-					doc.addField(fieldName, filterValues(values));
+					doc.addField(fieldName, values);
 				}
 			}
 		}
-	}
-
-	private List<String> filterValues(List<String> values) {
-		if (!values.isEmpty() && !multiValued ) {
-			values = Arrays.asList(values.get(0));
-		}
-		return values;
 	}
 
 	protected List<Map<String, List<String>>> getTextForQueries(Individual ind) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
@@ -3,96 +3,128 @@
 package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
 
 import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.createSelectQueryContext;
-
+import static edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup.PROPERTY_SELECTABLE_LOCALES;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.filter.LanguageFilteringRDFService;
+import edu.cornell.mannlib.vitro.webapp.utils.LocaleUtility;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationReader;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ContextModelsUser;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
-import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.StringResultsMapping;
 
 /**
- * A variation on SelectQueryDocument where the target field of the search
- * index document is specified in the query results.
- *
+ * A variation on SelectQueryDocument where the suffix of target field is defined.
+ * Multiple queries are performed for each of locales configured in runtime.properties
+ * 
+ * Target field names are composed of locale + fieldSuffix.
+ * 
  * Each query should contain a ?uri variable, which will be replaced by the URI
  * of the individual.
  * 
- * Each query must return a ?targetField variable specifying the name of the 
- * search document field to be populated. 
- *
- * All of the other result fields in each row of each query will
- * be converted to strings and added to the field specified in ?targetField.
+ * All of the other result fields in each row of each query will be converted to
+ * strings and added to the field.
+ * 
+ * By default only the first value is added to the field. To save all values
+ * specify :multiValued "true" in document modifier configuration. 
  *
  */
-public class SelectQueryDocumentModifierDynamicTargetField
-        extends SelectQueryDocumentModifier 
-        implements DocumentModifier, ContextModelsUser {
-    private static final Log log = LogFactory
-            .getLog(SelectQueryDocumentModifierDynamicTargetField.class);
-    
-    private static final String TARGET_FIELD_VAR = "targetField";
+public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDocumentModifier
+		implements DocumentModifier, ContextModelsUser, ConfigurationReader {
+	private static final Log log = LogFactory.getLog(SelectQueryDocumentModifierDynamicTargetField.class);
 
-    @Override
-    /**
-     * Grab the un-flattened query solution mappings and use the field name
-     * specified in the TARGET_FIELD_VAR variable as the location to store the 
-     * rest of the values.
-     */
-    public void modifyDocument(Individual ind, SearchInputDocument doc) {
-        if (passesTypeRestrictions(ind)) {
-            List<StringResultsMapping> values = getMappingsForQueries(ind);
-            for(StringResultsMapping value : values) {
-                for(Map<String, String> map : value.getListOfMaps()) {
-                    String targetFieldName = map.get(TARGET_FIELD_VAR);
-                    if(targetFieldName == null) {
-                        log.error(label + " select query must return variable "
-                            + TARGET_FIELD_VAR + " to specify document field"
-                                    + " in which to store remaining values");
-                    } else {
-                        for(String key : map.keySet()) {
-                            if(!TARGET_FIELD_VAR.equals(key)) {
-                                doc.addField(targetFieldName, map.get(key));
-                                if(log.isDebugEnabled()) {
-                                    log.debug("Added field " + targetFieldName
-                                            + " value " + map.get(key) + " to "
-                                            + ind.getURI());
-                                }
-                            }                                                       
-                        }
-                    }
-                }
-            }
-        }
-    }
+	private String fieldSuffix = "";
 
-    protected List<StringResultsMapping> getMappingsForQueries(Individual ind) {
-        List<StringResultsMapping> list = new ArrayList<>();
-        for (String query : queries) {
-            list.add(getQueryResults(query, ind));
-        }
-        return list;
-    }
+	private ArrayList<String> locales = new ArrayList<>();
 
-    protected StringResultsMapping getQueryResults(String query, Individual ind) {
-        try {
-            QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
-                    ind.getURI());
-            StringResultsMapping mapping = createSelectQueryContext(rdfService,
-                    queryHolder).execute().toStringFields();
-            log.debug(label + " query: '" + query + "' returns " + mapping);
-            return mapping;
-        } catch (Throwable t) {
-            log.error("problem while running query '" + query + "'", t);
-            return StringResultsMapping.EMPTY;
-        }
-    }
+	private boolean multiValued = false;
+
+	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasTargetSuffix")
+	public void setTargetSuffix(String fieldSuffix) {
+		this.fieldSuffix = fieldSuffix;
+	}
+
+	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#multiValued")
+	public void setMultiValued(String multiValued) {
+		this.multiValued = Boolean.parseBoolean(multiValued);
+	}
+
+	@Override
+	public void modifyDocument(Individual ind, SearchInputDocument doc) {
+		if (passesTypeRestrictions(ind) && StringUtils.isNotBlank(fieldSuffix)) {
+			List<Map<String, List<String>>> maps = getTextForQueries(ind);
+			for (Map<String, List<String>> map : maps) {
+				for (String locale : map.keySet()) {
+					List<String> values = map.get(locale);
+					String fieldName = locale + fieldSuffix; 
+					doc.addField(fieldName, filterValues(values));
+				}
+			}
+		}
+	}
+
+	private List<String> filterValues(List<String> values) {
+		if (!values.isEmpty() && !multiValued ) {
+			values = Arrays.asList(values.get(0));
+		}
+		return values;
+	}
+
+	protected List<Map<String, List<String>>> getTextForQueries(Individual ind) {
+		List<Map<String, List<String>>> list = new ArrayList<>();
+		for (String query : queries) {
+			list.add(getTextForQuery(query, ind));
+		}
+		return list;
+	}
+
+	protected Map<String, List<String>> getTextForQuery(String query, Individual ind) {
+		try {
+			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri", ind.getURI());
+			Map<String, List<String>> mapLocaleToFields = new HashMap<>();
+			for (String locale : locales) {
+				LanguageFilteringRDFService lfrs = new LanguageFilteringRDFService(rdfService,
+						Collections.singletonList(locale));
+				List<String> list = createSelectQueryContext(lfrs, queryHolder).execute().toStringFields().flatten();
+				mapLocaleToFields.put(locale, list);
+				log.debug(label + " for locale " + locale + " - query: '" + query + "' returns " + list);
+			}
+			return mapLocaleToFields;
+		} catch (Throwable t) {
+			log.error("problem while running query '" + query + "'", t);
+			return Collections.emptyMap();
+		}
+	}
+
+	@Override
+	public void setConfigurationProperties(ConfigurationProperties config) {
+		String property = config.getProperty(PROPERTY_SELECTABLE_LOCALES);
+		if (!StringUtils.isBlank(property)) {
+			String[] values = property.trim().split("\\s*,\\s*");
+			for (String value : values) {
+				addLocale(value);
+			}
+		}
+	}
+
+	private void addLocale(String localeString) {
+		if (StringUtils.isBlank(localeString)) {
+			return;	
+		}
+		locales.add(localeString);
+	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationReader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationReader.java
@@ -1,0 +1,13 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.utils.configuration;
+
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+
+/**
+ * When the ConfigurationBeanLoader creates an instance of this class, it will
+ * call this method, supplying ConfigurationProperties.
+ */
+public interface ConfigurationReader {
+	void setConfigurationProperties(ConfigurationProperties properties);
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.PropertyType.PropertyMethod;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.PropertyType.PropertyStatement;
@@ -60,6 +61,15 @@ public class WrappedInstance<T> {
 			} else {
 				RequestModelsUser rmu = (RequestModelsUser) instance;
 				rmu.setRequestModels(ModelAccess.on(req));
+			}
+		}
+		if (instance instanceof ConfigurationReader) {
+			if (ctx == null) {
+				throw new ResourceUnavailableException("Cannot satisfy "
+						+ "ConfigurationReader interface: context not available.");
+			} else {
+				ConfigurationReader cr = (ConfigurationReader) instance;
+				cr.setConfigurationProperties(ConfigurationProperties.getBean(ctx));
 			}
 		}
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -209,13 +209,11 @@ public class SearchQueryUtils {
     }
     
     public static String getSortFieldNameForLocale(Locale locale) {
-        return VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED + "_"
-            + locale.toString().replace('_', '-') + "_s";
+        return locale.toString() + VitroSearchTermNames.SORT_SUFFIX;
     }
     
     public static String getLabelFieldNameForLocale(Locale locale) {
-        return VitroSearchTermNames.NAME_RAW + "SingleValued_"
-            + locale.toString().replace('_', '-') + "_s";
+        return locale.toString() + VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
     }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -7,10 +7,9 @@
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual label document modifier" ;
     :hasTargetSuffix "_label_display" ;
-	:multiValued "false";
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?label WHERE {
+        SELECT ( MIN(?label) as ?singleLabel ) WHERE {
             ?uri rdfs:label ?label .
         }
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -6,11 +6,11 @@
     a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual label document modifier" ;
+    :hasTargetSuffix "_label_display" ;
+	:multiValued "false";
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?targetField (STR(MIN(?labelRaw)) AS ?label) WHERE {
-            ?uri rdfs:label ?labelRaw
-            FILTER("" != LANG(?labelRaw))
-            BIND(CONCAT("nameRawSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
-        } GROUP BY ?targetField
+        SELECT ?label WHERE {
+            ?uri rdfs:label ?label .
+        }
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -6,11 +6,11 @@
     a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual sort document modifier" ;
+    :hasTargetSuffix "_label_sort" ;
+	:multiValued "false";
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
-            ?uri rdfs:label ?labelRaw
-            FILTER("" != LANG(?labelRaw))
-            BIND(CONCAT("nameLowercaseSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
-        } GROUP BY ?targetField
+        SELECT ?label WHERE {
+            ?uri rdfs:label ?label .
+        }
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -7,10 +7,9 @@
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual sort document modifier" ;
     :hasTargetSuffix "_label_sort" ;
-	:multiValued "false";
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?label WHERE {
+        SELECT ( MIN(?label) as ?singleLabel ) WHERE {
             ?uri rdfs:label ?label .
         }
     """ .


### PR DESCRIPTION
Document modifier data properties:
:hasTargetSuffix "_label_sort" ;
Reads selectable locales from runtime.properties and performs queries for each locale, results are stored in fields with names 
locale + suffix.

Use with https://github.com/litvinovg/vivo-solr/tree/VIVO-3606